### PR TITLE
Update 08. Test the create form.md | Add info that the Django server must be running

### DIFF
--- a/tutorial/08. Test the create form.md
+++ b/tutorial/08. Test the create form.md
@@ -12,6 +12,8 @@ Execute the following:
 playwright codegen http://127.0.0.1:8000/
 ```
 
+Note: Your Django server must be running for playwright to be able to "attach" to it. So the `playwright codegen` command should be run from another terminal window. 
+
 See if you can get it to generate some useful code for you. You wont be able to get it to do all the things you want it to because some things are not yet implemented, but it'll give you a good starting point.
 
 You want to:


### PR DESCRIPTION
I initially ran into an error when running the playwright codegen:

```
❯ playwright codegen http://127.0.0.1:8000/
Error: net::ERR_CONNECTION_REFUSED at http://127.0.0.1:8000/
Call log:
  - navigating to "http://127.0.0.1:8000/", waiting until "load"
```

This was due to the Django server not running. Maybe it would be helpful to add a small note about this to the lesson materials.